### PR TITLE
build: fix link error on centos/rockylinux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- 4.4.6
+  - Upgrade to `kafka_protocol-4.2.8` for dependency (`crc32cer-1.0.4`) to fix its link error.
+
 - 4.4.5
   - Start supervisor process for the new increase partitions at `do_get_metadata` function.
   - Upgrade to `kafka_protocol-4.2.7` for fast dependency (`crc32cer-1.0.3`) build.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{kafka_protocol, "4.2.7"}]}.
+{deps, [{kafka_protocol, "4.2.8"}]}.
 {project_plugins, [{rebar3_lint, "~> 3.2.5"}]}.
 {edoc_opts, [{preprocess, true}]}.
 {erl_opts, [warnings_as_errors, warn_unused_vars,warn_shadow_vars,warn_obsolete_guard,debug_info]}.


### PR DESCRIPTION
fix link error

```
/usr/bin/ld: external/src/google-crc32c-build/libcrc32c.a(crc32c.cc.o): relocation R_X86_64_32 against `.bss' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld:
external/src/google-crc32c-build/libcrc32c.a(crc32c_sse42.cc.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld:
external/src/google-crc32c-build/libcrc32c.a(crc32c_portable.cc.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPI
```