### PR TITLE
251119 consumer group health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- 4.5.0
+  - Add `brod_group_subscriber_v2:health_check/2` to check topic-partition consumer connectivity status.
+
 - 4.4.7
   - Upgrade to `kafka_protocol-4.3.0` for improved message encoding performance. See [kafka_protocol changelog](https://github.com/kafka4beam/kafka_protocol/blob/master/changelog.md) for details.
   - Add a warning log when group coordinator 'EXIT' signal is received by `group_subscriber_v2`.

--- a/include/brod_int.hrl
+++ b/include/brod_int.hrl
@@ -76,6 +76,8 @@
 -define(BROD_LOG_INFO(Fmt, Args),    ?LOG_INFO(   Fmt, Args, #{domain => [brod]})).
 -define(BROD_LOG(Level, Fmt, Args),  ?LOG(Level,  Fmt, Args, #{domain => [brod]})).
 
+-define(MF_ERR_MAP(Reason), #{cause => Reason, module => ?MODULE, func => ?FUNCTION_NAME}).
+
 -endif. % include brod_int.hrl
 
 %%%_* Emacs ====================================================================

--- a/scripts/docker-compose-kraft.yml
+++ b/scripts/docker-compose-kraft.yml
@@ -18,6 +18,7 @@ services:
       - "9094:9094"
       - "9095:9095"
     environment:
+      KAFKA_connections__max__idle__ms: 30000
       BROKER_ID: 1
       CONTROLLER_PORT: 9090
       INNER_PORT: 9091
@@ -40,6 +41,7 @@ services:
       - "9194:9094"
       - "9195:9095"
     environment:
+      KAFKA_connections__max__idle__ms: 30000
       BROKER_ID: 2
       CONTROLLER_PORT: 9090
       INNER_PORT: 9091

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -300,7 +300,7 @@ debug(Pid, File) when is_list(File) ->
 get_connection(Pid) ->
   gen_server:call(Pid, get_connection).
 
-%% @doc Return 'true' if the payload connection is alive.
+%% @doc Return 'ok' if the payload connection is alive.
 -spec check_connectivity(pid(), pos_integer()) -> ok | {error, term()}.
 check_connectivity(Pid, Timeout) ->
   try

--- a/src/brod_consumer.erl
+++ b/src/brod_consumer.erl
@@ -44,6 +44,7 @@
         , stop_maybe_kill/2
         , subscribe/3
         , unsubscribe/2
+        , check_connectivity/2
         ]).
 
 %% Debug API
@@ -299,6 +300,21 @@ debug(Pid, File) when is_list(File) ->
 get_connection(Pid) ->
   gen_server:call(Pid, get_connection).
 
+%% @doc Return 'true' if the payload connection is alive.
+-spec check_connectivity(pid(), pos_integer()) -> ok | {error, term()}.
+check_connectivity(Pid, Timeout) ->
+  try
+    case gen_server:call(Pid, is_connected, Timeout) of
+      true ->
+        ok;
+      false ->
+        {error, disconnected}
+    end
+  catch
+    exit : Reason ->
+      {error, Reason}
+  end.
+
 %%%_* gen_server callbacks =====================================================
 
 init({Bootstrap0, Topic, Partition, Config}) ->
@@ -402,6 +418,8 @@ handle_info(Info, State) ->
   {noreply, State}.
 
 %% @private
+handle_call(is_connected, _From, #state{connection = C} = State) ->
+  {reply, is_pid(C) andalso is_process_alive(C), State};
 handle_call(get_connection, _From, #state{connection = C} = State) ->
   {reply, C, State};
 handle_call({subscribe, Pid, Options}, _From,

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -209,8 +209,8 @@ get_workers(Pid) ->
 get_workers(Pid, Timeout) ->
   gen_server:call(Pid, get_workers, Timeout).
 
-%% @doc Returns empty list if all workers are healthy,
-%% otherwise a list of errors.
+%% @doc Returns `ok' if all workers are healthy,
+%% otherwise `{error, Reasons}' where `Reasons' is a list of errors.
 -spec health_check(pid(), timeout()) -> ok | {error, [map()]}.
 health_check(Pid, Timeout) ->
   try

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -35,6 +35,7 @@
         , start_link/1
         , stop/1
         , get_workers/1
+        , health_check/2
         ]).
 
 %% brod_group_coordinator callbacks
@@ -208,6 +209,22 @@ get_workers(Pid) ->
 get_workers(Pid, Timeout) ->
   gen_server:call(Pid, get_workers, Timeout).
 
+%% @doc Returns empty list if all workers are healthy,
+%% otherwise a list of errors.
+-spec health_check(pid(), timeout()) -> ok | {error, [map()]}.
+health_check(Pid, Timeout) ->
+  try
+    case gen_server:call(Pid, {health_check, Timeout}, Timeout) of
+      [] ->
+        ok;
+      Errors ->
+        {error, Errors}
+    end
+  catch
+    exit : Reason ->
+      {error, [?MF_ERR_MAP(#{reason => Reason, group_subscriber => Pid})]}
+  end.
+
 %%%===================================================================
 %%% group_coordinator callbacks
 %%%===================================================================
@@ -315,6 +332,8 @@ handle_call({assign_partitions, Members, TopicPartitionList}, _From, State) ->
   {reply, Reply, State};
 handle_call(get_workers, _From, State = #state{workers = Workers}) ->
   {reply, Workers, State};
+handle_call({health_check, Timeout}, _From, State = #state{workers = Workers}) ->
+  {reply, do_health_check(Workers, Timeout), State};
 handle_call(Call, _From, State) ->
   {reply, {error, {unknown_call, Call}}, State}.
 
@@ -544,6 +563,25 @@ stop_consumers(Config) ->
         _ = brod_client:stop_consumer(Client, Topic)
     end,
     Topics).
+
+do_health_check(Workers0, Timeout) ->
+  Workers = lists:keysort(1, maps:to_list(Workers0)),
+  Fn = fun({{Topic, _Partition}, Pid}) ->
+         case brod_topic_subscriber:health_check(Pid, Timeout) of
+           [] ->
+             [];
+           [Error] ->
+             %% start one consumer for each topic
+             %% so it's always a one-element list
+             [Error#{topic => Topic}]
+         end
+       end,
+  try
+    lists:flatten(brod_utils:pmap(Fn, Workers, Timeout))
+  catch
+    throw : timeout ->
+      [?MF_ERR_MAP(timeout)]
+  end.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/src/brod_topic_subscriber.erl
+++ b/src/brod_topic_subscriber.erl
@@ -276,10 +276,10 @@ ack(Pid, Partition, Offset) ->
 -spec health_check(pid(), pos_integer()) -> [map()].
 health_check(Pid, Timeout) ->
   try
-    gen_server:call(Pid, {health_check, Timeout}, Timeout + 50)
+    gen_server:call(Pid, {health_check, Timeout}, Timeout)
   catch
     exit : Reason ->
-      ?MF_ERR_MAP(Reason)
+      [?MF_ERR_MAP(Reason)]
   end.
 
 %%%_* gen_server callbacks =====================================================

--- a/src/brod_utils.erl
+++ b/src/brod_utils.erl
@@ -60,6 +60,7 @@
         , resolve_offset/5
         , resolve_offset/6
         , kpro_connection_options/1
+        , pmap/3
         ]).
 
 -include("brod_int.hrl").
@@ -984,6 +985,39 @@ is_batch(_) -> false.
 
 nolink(C) when is_list(C) -> [{nolink, true} | C];
 nolink(C) when is_map(C) -> C#{nolink => true}.
+
+%% @doc Parallel map with timeout.
+-define(IS_TIMEOUT(T), ((is_integer(Timeout) andalso Timeout >= 0) orelse Timeout =:= infinity)).
+-spec pmap(fun((A) -> B), list(A), timeout()) -> list(B).
+pmap(_Fun, [], _Timeout) -> [];
+pmap(Fun, [_|_] = List, Timeout) when is_function(Fun, 1), ?IS_TIMEOUT(Timeout) ->
+  SeqL = lists:seq(1, length(List)),
+  Parent = self(),
+  Collector = erlang:spawn_link(fun() -> collect_pmap_results(Parent, SeqL, []) end),
+  Workers = lists:map(fun({Seq, Item}) ->
+                        erlang:spawn_link(fun() -> Collector ! {Seq, Fun(Item)} end)
+                      end, lists:zip(SeqL, List)),
+  receive
+    {Collector, Res} ->
+      Res
+  after Timeout ->
+    lists:foreach(fun unlink_kill/1, [Collector | Workers]),
+    throw(timeout)
+  end.
+
+unlink_kill(Pid) ->
+  unlink(Pid),
+  exit(Pid, kill),
+  ok.
+
+collect_pmap_results(Parent, [], Acc) ->
+  Parent ! {self(), lists:reverse(Acc)},
+  ok;
+collect_pmap_results(Parent, [Seq | SeqL], Acc) ->
+  receive
+    {Seq, Result} ->
+      collect_pmap_results(Parent, SeqL, [Result | Acc])
+  end.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -325,7 +325,7 @@ v2_health_check(Config) when is_list(Config) ->
            %% Send a message to ensure workers are established
            produce({Topic, Partition}, <<"test">>),
            {ok, _} = ?wait_message(Topic, Partition, <<"test">>, _),
-           %% Test 1: When all workers are healthy, should return empty list
+           %% Test 1: When all workers are healthy, should return ok.
            HealthResult1 = brod_group_subscriber_v2:health_check(SubscriberPid, Timeout),
            %% Test 2: Test with non-existent PID
            FakePid = list_to_pid("<0.999.0>"),
@@ -336,7 +336,7 @@ v2_health_check(Config) when is_list(Config) ->
          end,
          %% Check stage:
          fun({HealthResult1, HealthResult2}, _Trace) ->
-             %% When healthy, should return empty list
+             %% When healthy, should return ok.
              ct:pal("Health check result (healthy): ~p", [HealthResult1]),
              ?assertMatch(ok, HealthResult1),
              %% When process doesn't exist, should return error

--- a/test/brod_utils_tests.erl
+++ b/test/brod_utils_tests.erl
@@ -53,6 +53,64 @@ make_batch_input_test_() ->
 
 mk(K, V) -> brod_utils:make_batch_input(K, V).
 
+pmap_test_() ->
+  [fun() ->
+    %% Basic functionality - simple map operation
+    Result = brod_utils:pmap(fun(X) -> X * 2 end, [1, 2, 3, 4, 5], infinity),
+    ?assertEqual([2, 4, 6, 8, 10], Result)
+   end,
+   fun() ->
+    %% Empty list
+    Result = brod_utils:pmap(fun(X) -> X end, [], infinity),
+    ?assertEqual([], Result)
+   end,
+   fun() ->
+    %% Order preservation - results should be in same order as input
+    Result = brod_utils:pmap(fun(X) -> X end, [3, 1, 4, 1, 5], infinity),
+    ?assertEqual([3, 1, 4, 1, 5], Result)
+   end,
+   fun() ->
+    %% Numeric transformation
+    Result = brod_utils:pmap(fun(X) -> X + 1 end, [10, 20, 30], infinity),
+    ?assertEqual([11, 21, 31], Result)
+   end,
+   fun() ->
+    %% Large list
+    List = lists:seq(1, 100),
+    Result = brod_utils:pmap(fun(X) -> X * 2 end, List, infinity),
+    Expected = [X * 2 || X <- List],
+    ?assertEqual(Expected, Result)
+   end,
+   fun() ->
+     %% Timeout behavior - function that takes longer than timeout
+     StartTime = erlang:monotonic_time(millisecond),
+     try
+       brod_utils:pmap(fun(X) -> timer:sleep(200), X * 2 end, [1, 2, 3], 50),
+       %% Should not reach here
+       ?assert(false)
+       catch
+         throw:timeout ->
+           EndTime = erlang:monotonic_time(millisecond),
+           %% Should timeout quickly (within timeout + small overhead)
+           ?assert(EndTime - StartTime < 100)
+     end
+   end,
+   fun() ->
+     %% Infinity timeout - should complete successfully
+     Result = brod_utils:pmap(fun(X) -> timer:sleep(10), X * 2 end, [1, 2, 3], infinity),
+     ?assertEqual([2, 4, 6], Result)
+   end,
+   fun() ->
+     %% Single element list
+     Result = brod_utils:pmap(fun(X) -> X + 100 end, [42], infinity),
+     ?assertEqual([142], Result)
+   end,
+   fun() ->
+     %% Function that returns different types
+     Result = brod_utils:pmap(fun(X) -> {result, X} end, [1, 2, 3], infinity),
+     ?assertEqual([{result, 1}, {result, 2}, {result, 3}], Result)
+   end].
+
 %%%_* Emacs ====================================================================
 %%% Local Variables:
 %%% allout-layout: t


### PR DESCRIPTION
expose an API to check group consumer member's health status.

Note: one cannot check leader connectivity from `brod_client:get_leader_connection/3` because the topic-partition consumer by default starts its exclusive connection since version 4.2.0. `brod_client:get_leader_connection/3` will only establish a connection then continue to idle unless `share_leader_conn` is set to `true`.