### PR TITLE
fix: upgrade to kafka_protocol-4.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+- 4.5.3
+  - Pin kafka_protocol-4.3.4 (crc32cer-1.1.3 and kafka_protocol-4.3.4)
+    If a new re-authentication happens before the connection is still processing requests left-over from the previous re-authentication, the pending requests may get lost.
+    For producers, it means a synced produce call may timeout.
+    For consumers, if a fetch request was lost, it may cause the consumer process to stall indefinitely.
+
 - 4.5.2
   - Pin kafka_protocol-4.3.2 (crc32cer-1.1.2).
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{kafka_protocol, "4.3.2"}]}.
+{deps, [{kafka_protocol, "4.3.4"}]}.
 {project_plugins, [{rebar3_lint, "~> 3.2.5"}]}.
 {edoc_opts, [{preprocess, true}]}.
 {erl_opts, [warnings_as_errors, warn_unused_vars,warn_shadow_vars,warn_obsolete_guard,debug_info]}.


### PR DESCRIPTION
Fix a rare race condtion.
 
If a new re-authentication happens before the connection is still processing requests left-over from the previous re-authentication, the pending requests may get lost.
   
For producers, it means a synced produce call may timeout.
For consumers, if a fetch request was lost, it may cause the consumer process to stall indefinitely.