### PR TITLE
bug: OffsetFetch -1 silently drops partition, begin_offset falls back to undefined

### DIFF
--- a/test/brod_group_coordinator_SUITE.erl
+++ b/test/brod_group_coordinator_SUITE.erl
@@ -39,6 +39,7 @@
 %% Test cases
 -export([ t_acks_during_revoke/1
         , t_update_topics_triggers_rebalance/1
+        , t_offset_fetch_minus_one_silently_falls_back_to_begin_offset/1
         ]).
 
 -define(assert_receive(Pattern, Return),
@@ -49,6 +50,7 @@
   end).
 
 -include_lib("snabbkaffe/include/ct_boilerplate.hrl").
+-include_lib("kafka_protocol/include/kpro.hrl").
 -include("brod.hrl").
 
 %%%_* ct callbacks =============================================================
@@ -148,6 +150,65 @@ t_update_topics_triggers_rebalance(Config) when is_list(Config) ->
             fun(#brod_received_assignment{topic=Topic}) ->
               Topic == ?TOPIC1
             end, TopicAssignments)).
+
+%% When Kafka's OffsetFetch returns committed_offset=-1 (error_code=NONE), it
+%% means "no committed offset exists" — e.g. the group is new, the topic was
+%% deleted and recreated, or offsets.retention.minutes expired.
+%%
+%% Bug in get_committed_offsets/2: when Offset0 =:= -1, the partition is
+%% silently dropped from the result. resolve_begin_offsets/3 then returns
+%% begin_offset=undefined, and brod_group_subscriber falls back to consumer
+%% config (typically `latest`) with no error, no log, no alert.
+%%
+%% Desired behaviour: when OffsetFetch returns -1, surface it explicitly so
+%% the subscriber can apply offset_reset_policy — the same contract that
+%% OFFSET_OUT_OF_RANGE already provides.
+%%
+%% This test FAILS today — it demonstrates the gap, not the fix.
+%% Fix direction: in get_committed_offsets/2, when Offset0 =:= -1, add
+%%   {{Topic, Partition}, {error, no_committed_offset}} to the accumulator
+%%   and handle it in brod_group_subscriber like OFFSET_OUT_OF_RANGE.
+%% Expected result once fixed: assignments_received is called with a concrete
+%%   begin_offset for every partition (determined by offset_reset_policy), never
+%%   undefined. The subscriber must not silently fall back to consumer config.
+t_offset_fetch_minus_one_silently_falls_back_to_begin_offset({init, _Config}) ->
+  {skip, "known bug: OffsetFetch -1 silently drops partition, begin_offset=undefined"};
+t_offset_fetch_minus_one_silently_falls_back_to_begin_offset({'end', _Config}) ->
+  ok;
+t_offset_fetch_minus_one_silently_falls_back_to_begin_offset(Config) when is_list(Config) ->
+  meck:expect(brod_utils, request_sync,
+    fun(_Conn, #kpro_req{api = offset_fetch}, _Timeout) ->
+        {ok, fake_offset_fetch_minus_one_body(?TOPIC, ?PARTITION)};
+       (Conn, Req, Timeout) ->
+        meck:passthrough([Conn, Req, Timeout])
+    end),
+  {ok, CoordinatorPid} =
+    brod_group_coordinator:start_link(?CLIENT_ID, ?GROUP, [?TOPIC],
+                                      _Config = [], ?MODULE, {self(), 1}),
+  ?assert_receive({assignments_revoked, 1}, ok),
+  CoordinatorPid ! continue,
+  TopicAssignments = ?assert_receive({assignments_received, 1, _, TA}, TA),
+  %% begin_offset = undefined means brod silently fell back to consumer config.
+  %% This assertion FAILS today — fix should return {error, no_committed_offset}.
+  SilentFallbacks =
+    [A || #brod_received_assignment{begin_offset = undefined} = A <- TopicAssignments],
+  ?assertEqual([], SilentFallbacks).
+
+fake_offset_fetch_minus_one_body(Topic, Partition) ->
+  %% committed_offset=-1 with error_code=no_error is the Kafka protocol signal
+  %% for "no committed offset exists" (group is new, topic recreated, etc.).
+  [ {error_code, ?no_error}
+  , {topics, [ [ {name, Topic}
+               , {partitions, [ [ {partition_index, Partition}
+                                , {committed_offset, -1}
+                                , {metadata, <<>>}
+                                , {error_code, ?no_error}
+                                ]
+                              ]}
+               ]
+             ]}
+  ].
+
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:


### PR DESCRIPTION
When Kafka's OffsetFetch returns committed_offset=-1 with error_code=NONE, it signals that no committed offset exists — e.g. the group is new, the topic was deleted and recreated, or offsets.retention.minutes expired.

**The bug**

In get_committed_offsets/2, when Offset0 =:= -1, the partition is silently dropped from the result. resolve_begin_offsets/3 then returns begin_offset=undefined, and brod_group_subscriber falls back to consumer config (typically latest) with no error, no log, no alert. offset_reset_policy is never consulted.

**Fix direction**

In get_committed_offsets/2, when Offset0 =:= -1, add {{Topic, Partition}, {error, no_committed_offset}} to the accumulator and handle it in brod_group_subscriber like OFFSET_OUT_OF_RANGE.

**This PR**

Adds a test that demonstrates the gap. The test is currently skipped (known bug). Removing the skip is the acceptance criteria for the fix.