### PR TITLE
fix: stop silent fallback when OffsetFetch returns -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+- 4.5.4
+  - Fix silent fallback in `brod_group_subscriber`/`v2` when Kafka's `OffsetFetch` returns `committed_offset=-1`
+    (no committed offset for the group, e.g. new group, topic recreated, `offsets.retention.minutes` expired).
+    Previously the partition was silently dropped from the result and the subscriber started from the
+    consumer's default `begin_offset` (typically `latest`) with no log. The coordinator now surfaces
+    `{begin_offset, per_reset_policy}` in `#brod_received_assignment{}`, and the subscriber resolves it
+    via consumer config: `begin_offset` wins if set (backwards compatible), otherwise
+    `offset_reset_policy` is consulted; either fallback is logged.
+    [PR#660](https://github.com/kafka4beam/brod/pull/660),
+    [PR#661](https://github.com/kafka4beam/brod/pull/661).
+  - Fix `read_committed` isolation: `drop_aborted` could stop scanning too early when control records
+    from non-aborted transactions appeared before the abort marker, causing aborted batches to be
+    returned in the record set.
+    [PR#659](https://github.com/kafka4beam/brod/pull/659).
+
 - 4.5.3
   - Pin kafka_protocol-4.3.4 (crc32cer-1.1.3 and kafka_protocol-4.3.4)
     If a new re-authentication happens before the connection is still processing requests left-over from the previous re-authentication, the pending requests may get lost.

--- a/src/brod_group_coordinator.erl
+++ b/src/brod_group_coordinator.erl
@@ -986,7 +986,7 @@ get_topic_assignments(#state{} = State, Assignment) ->
 %% or call the consumer callback to read committed offsets.
 -spec get_committed_offsets(state(), [{brod:topic(), brod:partition()}]) ->
         [{{brod:topic(), brod:partition()},
-          brod:offset() | {begin_offset, brod:offset_time()}}].
+          brod:offset() | {begin_offset, brod:offset_time()} | ?undef}].
 get_committed_offsets(#state{ offset_commit_policy = consumer_managed
                             , member_pid           = MemberPid
                             , member_module        = MemberModule
@@ -1016,9 +1016,13 @@ get_committed_offsets(#state{ offset_commit_policy = commit_to_kafka_v2
             EC = kpro:find(error_code, PartitionOffset),
             ?ESCALATE_EC(EC),
             %% Offset -1 in offset_fetch_response is an indicator of 'no-value'
+            %% (e.g. new group, topic recreated, offsets.retention.minutes
+            %% expired). Surface it as ?undef so the subscriber can apply
+            %% offset_reset_policy rather than silently falling back to the
+            %% consumer config begin_offset.
             case Offset0 =:= -1 of
               true ->
-                Acc;
+                [{{Topic, Partition}, ?undef} | Acc];
               false ->
                 Offset = maybe_upgrade_from_roundrobin_v1(Offset0, Metadata),
                 [{{Topic, Partition}, Offset} | Acc]
@@ -1029,7 +1033,7 @@ get_committed_offsets(#state{ offset_commit_policy = commit_to_kafka_v2
 
 -spec resolve_begin_offsets(
         [TP],
-        [{TP, brod:offset() | {begin_offset, brod:offset_time()}}],
+        [{TP, brod:offset() | {begin_offset, brod:offset_time()} | ?undef}],
         boolean()) ->
           brod:received_assignments()
             when TP :: {brod:topic(), brod:partition()}.
@@ -1038,6 +1042,12 @@ resolve_begin_offsets([{Topic, Partition} | Rest], CommittedOffsets,
                       IsConsumerManaged) ->
   BeginOffset =
     case lists:keyfind({Topic, Partition}, 1, CommittedOffsets) of
+      {_, ?undef} ->
+        %% No committed offset (OffsetFetch returned -1, or the
+        %% consumer_managed callback returned ?undef explicitly). The
+        %% subscriber will resolve via the consumer config begin_offset /
+        %% offset_reset_policy.
+        ?undef;
       {_, {begin_offset, Offset}} ->
         %% already resolved
         resolve_special_offset(Offset);
@@ -1050,9 +1060,10 @@ resolve_begin_offsets([{Topic, Partition} | Rest], CommittedOffsets,
         %% offsets committed to kafka is already begin_offset
         %% since the introduction of 'roundrobin_v2' protocol
         Offset;
-      false  ->
-        %% No commit history found
-        %% Should use default begin_offset in consumer config
+      false ->
+        %% Partition missing from the result. Kafka omits partitions
+        %% with no committed offset in some response versions, so this
+        %% has the same "no committed offset" meaning.
         ?undef
     end,
   Assignment =

--- a/src/brod_group_subscriber.erl
+++ b/src/brod_group_subscriber.erl
@@ -578,14 +578,16 @@ consume_ack(Pid, Offset) ->
 do_commit_ack(Pid, GenerationId, Topic, Partition, Offset) ->
   ok = brod_group_coordinator:ack(Pid, GenerationId, Topic, Partition, Offset).
 
-subscribe_partitions(#state{ client    = Client
-                           , consumers = Consumers0
+subscribe_partitions(#state{ client          = Client
+                           , consumer_config = ConsumerConfig
+                           , consumers       = Consumers0
                            } = State) ->
   Consumers =
-    lists:map(fun(C) -> subscribe_partition(Client, C) end, Consumers0),
+    lists:map(fun(C) -> subscribe_partition(Client, ConsumerConfig, C) end,
+              Consumers0),
   {ok, State#state{consumers = Consumers}}.
 
-subscribe_partition(Client, Consumer) ->
+subscribe_partition(Client, ConsumerConfig, Consumer) ->
   #consumer{ topic_partition = {Topic, Partition}
            , consumer_pid    = Pid
            , begin_offset    = BeginOffset0
@@ -608,11 +610,7 @@ subscribe_partition(Client, Consumer) ->
                       ?undef        -> BeginOffset0;
                       N when N >= 0 -> N + 1
                     end,
-      Options =
-        case BeginOffset =:= ?undef of
-          true  -> []; %% fetch from 'begin_offset' in consumer config
-          false -> [{begin_offset, BeginOffset}]
-        end,
+      Options = subscribe_options(BeginOffset, ConsumerConfig, Topic, Partition),
       case brod:subscribe(Client, self(), Topic, Partition, Options) of
         {ok, ConsumerPid} ->
           Mref = erlang:monitor(process, ConsumerPid),
@@ -625,6 +623,39 @@ subscribe_partition(Client, Consumer) ->
                            }
       end
   end.
+
+%% Decide subscribe options based on the assigned begin_offset.
+%% `?undef' means the coordinator has no committed offset for this partition
+%% (OffsetFetch returned -1, the partition was omitted from the response, or
+%% the consumer_managed callback returned ?undef). Honour `begin_offset' in
+%% consumer config first (backwards compatible: pass no options and let the
+%% consumer use its configured start point), otherwise inject
+%% `{begin_offset, X}' derived from `offset_reset_policy'. Either way the
+%% choice is logged so the fallback is no longer silent.
+subscribe_options(?undef, ConsumerConfig, Topic, Partition) ->
+  case proplists:lookup(begin_offset, ConsumerConfig) of
+    {begin_offset, Offset} ->
+      ?BROD_LOG_INFO("No committed offset for ~s-~p, starting from "
+                     "consumer config begin_offset=~p",
+                     [Topic, Partition, Offset]),
+      []; %% consumer will use its configured begin_offset
+    none ->
+      Policy = proplists:get_value(offset_reset_policy, ConsumerConfig,
+                                   reset_by_subscriber),
+      Offset = reset_policy_to_offset(Policy),
+      ?BROD_LOG_INFO("No committed offset for ~s-~p, starting from ~p "
+                     "(offset_reset_policy=~p)",
+                     [Topic, Partition, Offset, Policy]),
+      [{begin_offset, Offset}]
+  end;
+subscribe_options(BeginOffset, _ConsumerConfig, _Topic, _Partition) ->
+  [{begin_offset, BeginOffset}].
+
+%% reset_by_subscriber has no equivalent at assignment time, so default to
+%% ?OFFSET_LATEST — matches brod_consumer's own default begin_offset.
+reset_policy_to_offset(reset_to_earliest) -> ?OFFSET_EARLIEST;
+reset_policy_to_offset(reset_to_latest)   -> ?OFFSET_LATEST;
+reset_policy_to_offset(_)                 -> ?OFFSET_LATEST.
 
 log(#state{ groupId  = GroupId
           , memberId = MemberId

--- a/src/brod_group_subscriber_v2.erl
+++ b/src/brod_group_subscriber_v2.erl
@@ -490,11 +490,13 @@ terminate_worker(WorkerPid) ->
                         , brod:consumer_config()
                         , brod:topic()
                         , brod:partition()
-                        , brod:offset() | undefined
+                        , undefined
+                          | brod:offset()
+                          | {begin_offset, brod:offset_time()}
                         , state()
                         ) -> state().
 maybe_start_worker( _MemberId
-                  , ConsumerConfig
+                  , ConsumerConfig0
                   , Topic
                   , Partition
                   , BeginOffset
@@ -512,6 +514,8 @@ maybe_start_worker( _MemberId
     #{TopicPartition := _Worker} ->
       State;
     _ ->
+      ConsumerConfig =
+        maybe_apply_reset_policy(BeginOffset, ConsumerConfig0, Topic, Partition),
       Self = self(),
       CommitFun = fun(Offset) -> commit(Self, Topic, Partition, Offset) end,
       AckFun = fun(Offset) -> ack(Self, Topic, Partition, Offset) end,
@@ -566,6 +570,40 @@ do_ack(Topic, Partition, Offset, #state{ workers = Workers
     _ ->
       {error, unknown_topic_or_partition}
   end.
+
+%% When the coordinator has no committed offset for this partition
+%% (`BeginOffset = ?undef'), make the fallback explicit: honour
+%% `begin_offset' in consumer config first (backwards compatible
+%% start-point override), otherwise inject `{begin_offset, X}' from
+%% `offset_reset_policy'. Either way the chosen offset is logged so the
+%% start-up choice is no longer silent. `?undef' is then passed through
+%% to the worker — the consumer applies the (possibly updated)
+%% `begin_offset' from its config.
+maybe_apply_reset_policy(?undef, ConsumerConfig, Topic, Partition) ->
+  case proplists:is_defined(begin_offset, ConsumerConfig) of
+    true ->
+      ?BROD_LOG_INFO("No committed offset for ~s-~p, starting from "
+                     "consumer config begin_offset=~p",
+                     [Topic, Partition,
+                      proplists:get_value(begin_offset, ConsumerConfig)]),
+      ConsumerConfig;
+    false ->
+      Policy = proplists:get_value(offset_reset_policy, ConsumerConfig,
+                                   reset_by_subscriber),
+      Offset = reset_policy_to_offset(Policy),
+      ?BROD_LOG_INFO("No committed offset for ~s-~p, starting from ~p "
+                     "(offset_reset_policy=~p)",
+                     [Topic, Partition, Offset, Policy]),
+      [{begin_offset, Offset} | ConsumerConfig]
+  end;
+maybe_apply_reset_policy(_BeginOffset, ConsumerConfig, _Topic, _Partition) ->
+  ConsumerConfig.
+
+%% reset_by_subscriber has no equivalent at assignment time, so default to
+%% ?OFFSET_LATEST — matches brod_consumer's own default begin_offset.
+reset_policy_to_offset(reset_to_earliest) -> ?OFFSET_EARLIEST;
+reset_policy_to_offset(reset_to_latest)   -> ?OFFSET_LATEST;
+reset_policy_to_offset(_)                 -> ?OFFSET_LATEST.
 
 stop_consumers(Config) ->
   #{ client := Client

--- a/test/brod_group_coordinator_SUITE.erl
+++ b/test/brod_group_coordinator_SUITE.erl
@@ -39,6 +39,7 @@
 %% Test cases
 -export([ t_acks_during_revoke/1
         , t_update_topics_triggers_rebalance/1
+        , t_offset_fetch_minus_one_falls_back_to_reset_policy/1
         ]).
 
 -define(assert_receive(Pattern, Return),
@@ -49,6 +50,7 @@
   end).
 
 -include_lib("snabbkaffe/include/ct_boilerplate.hrl").
+-include_lib("kafka_protocol/include/kpro.hrl").
 -include("brod.hrl").
 
 %%%_* ct callbacks =============================================================
@@ -148,6 +150,100 @@ t_update_topics_triggers_rebalance(Config) when is_list(Config) ->
             fun(#brod_received_assignment{topic=Topic}) ->
               Topic == ?TOPIC1
             end, TopicAssignments)).
+
+%% When Kafka's OffsetFetch returns committed_offset=-1 (error_code=NONE), it
+%% means "no committed offset exists" (e.g. new group, topic recreated,
+%% offsets.retention.minutes expired). Previously the partition was silently
+%% dropped, begin_offset became `undefined', and brod_group_subscriber fell
+%% back to the consumer's default begin_offset with no log.
+%%
+%% After the fix the assignment carries begin_offset=undefined for those
+%% partitions and the subscriber resolves it via the consumer config's
+%% begin_offset / offset_reset_policy with a log entry. With
+%% reset_to_earliest, the consumer's first Fetch request must target
+%% offset 0, not "latest".
+t_offset_fetch_minus_one_falls_back_to_reset_policy({init, Config}) ->
+  meck:new(brod_utils, [passthrough]),
+  meck:new(brod_kafka_request, [passthrough]),
+  Config;
+t_offset_fetch_minus_one_falls_back_to_reset_policy({'end', _Config}) ->
+  meck:unload(brod_kafka_request),
+  meck:unload(brod_utils),
+  ok;
+t_offset_fetch_minus_one_falls_back_to_reset_policy(Config) when is_list(Config) ->
+  Topic = ?TOPIC,
+  %% Topic has 3 partitions (created by setup-test-env.sh).
+  Partitions = [0, 1, 2],
+  %% Produce a message so the partition has a non-zero high-watermark.
+  %% earliest is still offset 0 regardless of HWM.
+  {ok, _} = brod:produce_sync_offset(?CLIENT_ID, Topic, ?PARTITION,
+                                     <<>>, <<"msg">>),
+  %% Inject a fake OffsetFetch response: committed_offset=-1 for every
+  %% partition ("no committed offset").
+  FakeBody = fake_offset_fetch_minus_one_body(Topic, Partitions),
+  meck:expect(brod_utils, request_sync,
+    fun(_Conn, #kpro_req{api = offset_fetch}, _Timeout) ->
+        {ok, FakeBody};
+       (Conn, Req, Timeout) ->
+        meck:passthrough([Conn, Req, Timeout])
+    end),
+  %% Capture the offset arg of the first Kafka Fetch request per partition.
+  Self = self(),
+  meck:expect(brod_kafka_request, fetch,
+    fun(Pid, T, P, Offset, WT, MinB, MaxB, IL) ->
+        Self ! {fetch, T, P, Offset},
+        meck:passthrough([Pid, T, P, Offset, WT, MinB, MaxB, IL])
+    end),
+  %% Start a real v2 subscriber with reset_to_earliest. A unique group id is
+  %% not strictly required (the OffsetFetch meck overrides), but it avoids
+  %% interacting with offsets committed by earlier test cases.
+  GroupId = list_to_binary(
+              "brod-grp-coord-no-commit-" ++
+              integer_to_list(erlang:unique_integer([positive]))),
+  ConsumerConfig = [{offset_reset_policy, reset_to_earliest}],
+  {ok, SubscriberPid} =
+    brod:start_link_group_subscriber_v2(
+      #{ client          => ?CLIENT_ID
+       , group_id        => GroupId
+       , topics          => [Topic]
+       , group_config    => []
+       , consumer_config => ConsumerConfig
+       , cb_module       => brod_test_group_subscriber
+       , init_data       => #{}
+       }),
+  try
+    FetchOffset = receive
+                    {fetch, Topic, ?PARTITION, O} -> O
+                  after 30000 ->
+                    ct:fail({no_fetch_observed,
+                             erlang:process_info(self(), messages)})
+                  end,
+    %% offset_reset_policy=reset_to_earliest => first fetch at offset 0.
+    %% Pre-fix: would have been the HWM (>=1) since "latest" is the consumer
+    %% default begin_offset.
+    ?assertEqual(0, FetchOffset)
+  after
+    ok = brod_group_subscriber_v2:stop(SubscriberPid)
+  end.
+
+%% Build an OffsetFetch response returning committed_offset=-1 for every
+%% listed partition of `Topic'.
+fake_offset_fetch_minus_one_body(Topic, Partitions) ->
+  [ {error_code, ?no_error}
+  , {topics,
+     [ [ {name, Topic}
+       , {partitions,
+          [ [ {partition_index, P}
+            , {committed_offset, -1}
+            , {metadata, <<>>}
+            , {error_code, ?no_error}
+            ]
+            || P <- Partitions
+          ]}
+       ]
+     ]}
+  ].
+
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:


### PR DESCRIPTION
## Summary

When Kafka's `OffsetFetch` returns `committed_offset=-1` (or omits the partition entirely), `brod` previously dropped the partition from the result. The assignment then carried `begin_offset=undefined` and the subscriber silently fell back to the consumer's default `begin_offset` (typically `latest`), with no log line and no way for the application to react.

After this PR the assignment still carries `undefined` for those partitions, but the subscribers (`brod_group_subscriber` and `brod_group_subscriber_v2`) resolve it explicitly:

- If consumer config has `begin_offset`, use it (backwards compatible start-point override).
- Otherwise derive `begin_offset` from `offset_reset_policy` (`reset_to_earliest` -> `earliest`, `reset_to_latest` / default -> `latest`).
- Either way the choice is logged so the fallback is no longer silent.

The CHANGELOG has been updated for 4.5.4.

## Credit

Continues #660 — the original test scaffold and bug report are from @flysen.

## Test

`test/brod_group_coordinator_SUITE:t_offset_fetch_minus_one_falls_back_to_reset_policy` starts a real `brod_group_subscriber_v2` with `offset_reset_policy=reset_to_earliest`, mecks `brod_utils:request_sync` to return `committed_offset=-1`, mecks `brod_kafka_request:fetch/8` to capture the offset issued in the first Kafka Fetch request, and asserts it targets offset `0`. Verified the test fails (got `7`, the HWM) without the fix.

## Test plan

- [x] New test passes with the fix; fails without (silent fallback to `latest`)
- [x] `brod_group_coordinator_SUITE` (3/3), `brod_group_subscriber_SUITE` (23/23), `brod_cg_commits_SUITE` + `brod_offset_txn_SUITE` (3/3) green
- [x] `rebar3 dialyzer` clean