### PR TITLE
fix(client): break brod_client ↔ producers_sup deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@
     instead of once per stabilize cycle, producing duplicate revoke
     callbacks on any retry path.
     Added Kafka 2.2 to the CI matrix.
+  - Fix deadlock between `brod_client' and a per-topic `brod_producers_sup'
+    (issue #662; regression in 4.4.5 / PR #636 widened exposure).
+    The producer supervisor's `post_init/1' callback called back into
+    `brod_client' via `brod_client:get_partitions_count/2', forming a cycle
+    with `brod_client''s own `count_started_children/1' walk inside
+    `do_get_metadata' — when an `auto_start_producer' call arrived in
+    `brod_client''s mailbox before a concurrent per-topic supervisor's
+    `post_init/1' callback queued its own request, the two processes would
+    block on each other indefinitely with `timeout=infinity'.
+    `brod_client' now pre-supplies the partition count from its workers
+    table cache (populated by `validate_topic_existence/3' immediately
+    before) via the new `brod_producers_sup:start_topic_producer/5'. The
+    per-topic supervisor's `post_init/1' uses the supplied count and no
+    longer calls back into `brod_client', breaking the cycle. The 4-arity
+    `brod_producers_sup:start_producer/4' is kept for backward compatibility
+    with external callers that do not know the partition count.
 
 - 4.5.4
   - Fix silent fallback in `brod_group_subscriber`/`v2` when Kafka's `OffsetFetch` returns `committed_offset=-1`

--- a/src/brod_client.erl
+++ b/src/brod_client.erl
@@ -961,15 +961,26 @@ request_sync(State, Request) ->
 
 do_start_producer(TopicName, ProducerConfig, State) ->
   SupPid = State#state.producers_sup,
-  F = fun() ->
-        brod_producers_sup:start_producer(SupPid, self(),
-                                          TopicName, ProducerConfig)
+  %% Issue #662: pre-supply the partition count from the cache (just populated
+  %% by validate_topic_existence) so the per-topic producers supervisor's
+  %% post_init does not need to call back into this brod_client process —
+  %% which would deadlock when brod_client is in `count_started_children'
+  %% walking the supervisor tree.
+  F = fun(NewState) ->
+        PartitionsCount =
+          case lookup_partitions_count_cache(NewState#state.workers_tab,
+                                             TopicName) of
+            {ok, N} -> N;
+            _       -> undefined
+          end,
+        brod_producers_sup:start_topic_producer(
+          SupPid, self(), TopicName, PartitionsCount, ProducerConfig)
       end,
   ensure_partition_workers(TopicName, State, F).
 
 do_start_consumer(TopicName, ConsumerConfig, State) ->
   SupPid = State#state.consumers_sup,
-  F = fun() ->
+  F = fun(_NewState) ->
         brod_consumers_sup:start_consumer(SupPid, self(),
                                           TopicName, ConsumerConfig)
       end,
@@ -979,7 +990,7 @@ ensure_partition_workers(TopicName, State, F) ->
   with_ok(
     validate_topic_existence(TopicName, State, _IsRetry = false),
     fun(ok, NewState) ->
-      case F() of
+      case F(NewState) of
         {ok, _Pid} ->
           {ok, NewState};
         {error, {already_started, _Pid}} ->

--- a/src/brod_producers_sup.erl
+++ b/src/brod_producers_sup.erl
@@ -28,6 +28,7 @@
         , find_producer/3
         , start_producer/4
         , start_producer/5
+        , start_topic_producer/5
         , stop_producer/2
         , get_producer_config/3
         , count_started_children/1
@@ -56,11 +57,35 @@
 start_link() ->
   brod_supervisor3:start_link(?MODULE, ?TOPICS_SUP).
 
-%% @doc Dynamically start a per-topic supervisor
+%% @doc Dynamically start a per-topic supervisor.
+%%
+%% The per-topic supervisor will discover the partition count by calling
+%% `brod_client:get_partitions_count/2' from its `post_init/1' callback.
+%% That callback runs a synchronous `gen_server:call' into `brod_client',
+%% and can deadlock with `brod_client' if `brod_client' is concurrently
+%% walking the producer supervisor tree (e.g. inside
+%% `count_started_children/1' from `do_get_metadata') — see issue #662.
+%% Prefer `start_topic_producer/5' from `brod_client' callers; this 4-arity
+%% variant is kept for backward compatibility with external callers that
+%% do not know the partition count up front.
 -spec start_producer(pid(), pid(), brod:topic(), brod:producer_config()) ->
                         {ok, pid()} | {error, any()}.
 start_producer(SupPid, ClientPid, TopicName, Config) ->
-  Spec = producers_sup_spec(ClientPid, TopicName, Config),
+  start_topic_producer(SupPid, ClientPid, TopicName, undefined, Config).
+
+%% @doc Dynamically start a per-topic supervisor with a known partition count.
+%%
+%% Bypasses the `post_init' callback's `brod_client:get_partitions_count/2'
+%% call by supplying the count up front. This is what `brod_client' uses
+%% from `do_start_producer/3' after its own `validate_topic_existence/3'
+%% has populated the partition count cache — eliminating the deadlock
+%% cycle described in issue #662.
+-spec start_topic_producer(pid(), pid(), brod:topic(),
+                           pos_integer() | undefined,
+                           brod:producer_config()) ->
+                              {ok, pid()} | {error, any()}.
+start_topic_producer(SupPid, ClientPid, TopicName, PartitionsCount, Config) ->
+  Spec = producers_sup_spec(ClientPid, TopicName, PartitionsCount, Config),
   brod_supervisor3:start_child(SupPid, Spec).
 
 %% @doc Dynamically start a partition producer
@@ -155,11 +180,11 @@ which_producers(Sup) ->
 %% @doc brod_supervisor3 callback.
 init(?TOPICS_SUP) ->
   {ok, {{one_for_one, 0, 1}, []}};
-init({?PARTITIONS_SUP, _ClientPid, _Topic, _Config}) ->
+init({?PARTITIONS_SUP, _ClientPid, _Topic, _PartitionsCount, _Config}) ->
   post_init.
 
-post_init({?PARTITIONS_SUP, ClientPid, Topic, Config}) ->
-  case brod_client:get_partitions_count(ClientPid, Topic) of
+post_init({?PARTITIONS_SUP, ClientPid, Topic, PartitionsCount, Config}) ->
+  case resolve_partitions_count(ClientPid, Topic, PartitionsCount) of
     {ok, PartitionsCnt} ->
       Children = [ producer_spec(ClientPid, Topic, Partition, Config)
                  || Partition <- lists:seq(0, PartitionsCnt - 1) ],
@@ -173,11 +198,20 @@ post_init({?PARTITIONS_SUP, ClientPid, Topic, Config}) ->
       {error, Reason}
   end.
 
-producers_sup_spec(ClientPid, TopicName, Config0) ->
+%% Use the pre-supplied partition count when available (the deadlock-free
+%% path used by brod_client). Fall back to brod_client:get_partitions_count/2
+%% only when the caller did not know the count.
+resolve_partitions_count(_ClientPid, _Topic, N)
+    when is_integer(N), N > 0 ->
+  {ok, N};
+resolve_partitions_count(ClientPid, Topic, _Undefined) ->
+  brod_client:get_partitions_count(ClientPid, Topic).
+
+producers_sup_spec(ClientPid, TopicName, PartitionsCount, Config0) ->
   {Config, DelaySecs} =
     take_delay_secs(Config0, topic_restart_delay_seconds,
                     ?DEFAULT_PARTITIONS_SUP_RESTART_DELAY),
-  Args = [?MODULE, {?PARTITIONS_SUP, ClientPid, TopicName, Config}],
+  Args = [?MODULE, {?PARTITIONS_SUP, ClientPid, TopicName, PartitionsCount, Config}],
   { _Id       = TopicName
   , _Start    = {brod_supervisor3, start_link, Args}
   , _Restart  = {permanent, DelaySecs}

--- a/test/brod_client_SUITE.erl
+++ b/test/brod_client_SUITE.erl
@@ -46,6 +46,7 @@
         , t_get_partitions_count_configure_cache_ttl/1
         , t_get_partitions_count_safe/1
         , t_double_stop_consumer/1
+        , t_start_producer_does_not_post_init_callback/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -481,6 +482,53 @@ mock_connection(EP) ->
   Ref.
 
 kafka_version() -> kafka_test_helper:kafka_version().
+
+%% Regression for issue #662: brod_client and brod_producers_sup could
+%% deadlock when brod_client's `do_get_metadata' walked the producer
+%% supervisor tree via `count_started_children/1' while a per-topic
+%% supervisor was sitting in its `post_init/1' callback waiting for
+%% brod_client to answer `get_partitions_count/2'.
+%%
+%% The fix is for brod_client to pre-supply the partition count to
+%% `brod_producers_sup:start_topic_producer/5' so the new per-topic
+%% supervisor's `post_init/1' never calls back into brod_client. This
+%% test asserts that property white-box: after `brod:start_producer/3'
+%% (which goes through the same `do_start_producer/3' path as the
+%% `auto_start_producers' flow that exposed the deadlock), no
+%% `brod_client:get_partitions_count/2' call should originate from the
+%% per-topic supervisor's `post_init/1' callback. Before the fix this
+%% count would be at least 1 (one call per per-topic supervisor created).
+t_start_producer_does_not_post_init_callback({init, Config}) ->
+  meck:new(brod_client, [passthrough]),
+  Config;
+t_start_producer_does_not_post_init_callback({'end', Config}) ->
+  meck:unload(brod_client),
+  brod:stop_client(t_start_producer_does_not_post_init_callback),
+  Config;
+t_start_producer_does_not_post_init_callback(Config) when is_list(Config) ->
+  Client = t_start_producer_does_not_post_init_callback,
+  Topic = ?TOPIC,
+  ok = start_client(?HOSTS, Client),
+  %% Warm the partition count cache via a direct call so the counter below
+  %% only attributes new calls to the per-topic supervisor's `post_init/1'.
+  {ok, _} = brod_client:get_partitions_count(Client, Topic),
+  %% From here on, every `brod_client:get_partitions_count/2' call must come
+  %% from `brod_producers_sup:post_init/1' — there is no other caller in the
+  %% `start_producer' code path.
+  Counter = counters:new(1, []),
+  meck:expect(brod_client, get_partitions_count,
+    fun(C, T) ->
+        counters:add(Counter, 1, 1),
+        meck:passthrough([C, T])
+    end),
+  ok = brod:start_producer(Client, Topic, []),
+  %% Allow the per-topic supervisor's `handle_continue' / `post_init/1' to run.
+  ok = timer:sleep(200),
+  ?assertEqual(
+    0, counters:get(Counter, 1),
+    "brod_producers_sup:post_init/1 must not call back into brod_client "
+    "when brod_client has pre-supplied the partition count"),
+  ok.
 
 start_client(Hosts, ClientId) -> start_client(Hosts, ClientId, []).
 


### PR DESCRIPTION
## Summary

Fixes #662. `brod_producers_sup:post_init/1` called back into `brod_client` via `brod_client:get_partitions_count/2`, forming a cycle with `brod_client`'s own `count_started_children/1` walk inside `do_get_metadata`. When an `auto_start_producer` call arrived in `brod_client`'s mailbox before a concurrent per-topic supervisor's `post_init/1` callback queued its own request, the two processes blocked on each other indefinitely with `timeout=infinity`.

PR #636 (4.4.5) widened the exposure by adding the `count_started_children` walk inside the metadata path — every metadata fetch from inside `auto_start_producer` now touches every per-topic supervisor.

## The cycle

```
PartitionsSup_X  (in handle_continue → post_init/1)        brod_client
  └── gen_server:call(brod_client,                            └── handle_call({auto_start_producer, TopicY})
        get_workers_table, infinity)                                └── do_get_metadata
            ↓ queued in brod_client mailbox                                └── count_started_children(TopSup)
                                                                                  └── for each per-topic sup PSup_i:
                                                                                        gen_server:call(PSup_i,
                                                                                          which_children, infinity)
                                                                                  ↓ blocks on PartitionsSup_X
                                                                                    (which is in post_init)
```

## Fix

`brod_client` pre-supplies the partition count from its workers table cache (populated by `validate_topic_existence/3` immediately before) via the new `brod_producers_sup:start_topic_producer/5`. The per-topic supervisor's `post_init/1` uses the supplied count and no longer calls back into `brod_client`. The 4-arity `brod_producers_sup:start_producer/4` is kept for backward compatibility with external callers that do not know the partition count.

## Alternatives considered

| Option | Why not |
|---|---|
| Non-blocking `which_children` with short timeout | Band-aid; masks the cycle, may miss new producers on busy sups |
| Async/non-blocking `post_init` callback | Restructures supervisor init contract; intrusive |
| Smuggle count via `Config` hint | Same effect as picked option but pollutes user-visible config |

The picked option breaks the cycle at its source, single-direction, with no semantic change for users.

## Test plan

- [x] New regression test `t_start_producer_does_not_post_init_callback` in `brod_client_SUITE`: meck `brod_client:get_partitions_count/2` with a counter, run `brod:start_producer/3`, allow 200ms for `handle_continue` → `post_init/1` to run, then assert the counter is 0.
  - **Pre-fix:** `expected: 0, got: 1` (one call per per-topic sup created — confirmed by stashing the fix).
  - **Post-fix:** counter stays at 0.
- [x] Full ct + prop suite on Kafka 4.0: **116 ct + 500 prop runs pass.**
- [x] Full ct + prop suite on Kafka 2.2.2: **118 ct + 500 prop runs pass.**
- [x] `rebar3 xref,dialyzer`: clean.

## Residual risk

External callers of the private `brod_producers_sup:start_producer/4` (anyone bypassing `brod_client`) still trigger the `post_init` callback into `brod_client` and can deadlock under the same race. `brod_producers_sup` is marked `@private` so this is acceptable; the docstring now points such callers at `start_topic_producer/5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)