### PR TITLE
fix(producer): treat kafka_storage_error as retriable

### DIFF
--- a/src/brod_producer.erl
+++ b/src/brod_producer.erl
@@ -618,7 +618,8 @@ is_retriable(EC) when EC =:= ?unknown_topic_or_partition;
                       EC =:= ?not_leader_for_partition;
                       EC =:= ?request_timed_out;
                       EC =:= ?not_enough_replicas;
-                      EC =:= ?not_enough_replicas_after_append ->
+                      EC =:= ?not_enough_replicas_after_append;
+                      EC =:= ?kafka_storage_error ->
   true;
 is_retriable(_) ->
   false.

--- a/test/brod_producer_stub_SUITE.erl
+++ b/test/brod_producer_stub_SUITE.erl
@@ -30,6 +30,7 @@
 -export([ t_normal_flow/1
         , t_no_required_acks/1
         , t_retry_on_same_connection/1
+        , t_retry_on_kafka_storage_error/1
         , t_connection_down_retry/1
         , t_leader_migration/1
         ]).
@@ -178,6 +179,50 @@ t_retry_on_same_connection(Config) when is_list(Config) ->
           {produce, ProducerPid, #kpro_req{ref = Ref}} ->
             Rsp = case N of
                     1 -> fake_rsp(Ref, <<"topic">>, 0, ?request_timed_out);
+                    2 -> fake_rsp(Ref, <<"topic">>, 0)
+                  end,
+            Tester ! {'try', N},
+            ProducerPid ! {msg, self(), Rsp},
+            Loop(N + 1)
+        end
+    end,
+  ConnPid = erlang:spawn_link(fun() -> ConnLoop(1) end),
+  meck:expect(brod_client, get_leader_connection,
+              fun(client, <<"topic">>, 0) ->
+                  {ok, ConnPid}
+              end),
+  ProducerConfig = [{required_acks, 1},
+                    {max_linger_ms, 0},
+                    {retry_backoff_ms, 100}],
+  {ok, Producer} = brod_producer:start_link(client, <<"topic">>, 0,
+                                            ProducerConfig),
+  meck:expect(kpro, request_async,
+              fun(Connection, Req) ->
+                  Connection ! {produce, Producer, Req},
+                  ok
+              end),
+  {ok, CallRef} = brod_producer:produce(Producer, <<"k">>, <<"v">>),
+  ?WAIT({'try', 1}, ok, 1000),
+  ?WAIT({'try', 2}, ok, 1000),
+  ?WAIT(#brod_produce_reply{call_ref = CallRef,
+                            result = brod_produce_req_acked},
+        ok, 2000),
+  ok = brod_producer:stop(Producer).
+
+%% kafka_storage_error (error code 56) is retriable per the Kafka protocol.
+%% Expect brod_producer to keep the buffer and retry
+%% instead of exiting with {not_retriable, _}.
+t_retry_on_kafka_storage_error(Config) when is_list(Config) ->
+  Tester = self(),
+  %% A mocked connection process which expects 2 requests to be sent
+  %% reply kafka_storage_error for the first one
+  %% and succeed the second one
+  ConnLoop =
+    fun Loop(N) ->
+        receive
+          {produce, ProducerPid, #kpro_req{ref = Ref}} ->
+            Rsp = case N of
+                    1 -> fake_rsp(Ref, <<"topic">>, 0, ?kafka_storage_error);
                     2 -> fake_rsp(Ref, <<"topic">>, 0)
                   end,
             Tester ! {'try', N},


### PR DESCRIPTION
Hey all! Andrea from the Elixir core team here.

We just started using `brod` (under `broadway_kafka`) at [Knock](https://knock.app/), for communicating with [WarpStream](https://www.warpstream.com/).

This PR adds `?kafka_storage_error` (KAFKA_STORAGE_ERROR, error code 56) to `brod_producer:is_retriable/1`, so a produce response carrying it nacks the buffer and schedules a retry (same path as `request_timed_out`) instead of exiting the producer with `{not_retriable, _}`.

The idea is that the Kafka protocol classifies error 56 as **Retriable=True** ("Disk error when trying to access log file on the disk"; see the [protocol error table](https://kafka.apache.org/protocol#protocol_error_codes)). For example, the Java client automatically retries it on Produce. `brod` currently treats it as fatal.

The failure mode is worse than a plain error: `exit({not_retriable, _})` kills the producer and loses its whole internal buffer, so a transient broker-side storage blip becomes message loss for any caller that doesn't wrap brod in its own retry layer.

We noticed this because we use WarpStream (Kafka-compatible, S3-backed), which uses `KAFKA_STORAGE_ERROR` as its generic "back off and retry" code. Their docs [explicitly call it "a retriable error code"](https://docs.warpstream.com/warpstream/kafka/configure-kafka-client/known-issues) and several [changelog entries](https://docs.warpstream.com/warpstream/overview/change-log) pick error 56 precisely because compliant clients treat it as transient.

I'm opening this because in production we observed a single WarpStream-side blip take down a bunch of `brod` producers (across 12 pods within 15ms 😮), all with `{not_retriable, {produce_response_error, Topic, Partition, -1, kafka_storage_error}}`.