### PR TITLE
OTP-29 fixes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
   {test, [
     {deps, [ {hut, "1.3.0"}
            , {jsone, "1.7.0"}
-           , {meck, "0.9.2"}
+           , {meck, "1.2.0"}
            , {proper, "1.5.0"}
            , {snappyer, "1.2.9"}
            , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {branch, "1.0.10"}}}

--- a/src/brod_supervisor3.erl
+++ b/src/brod_supervisor3.erl
@@ -408,7 +408,7 @@ start_children([], NChildren, _SupName) ->
 
 do_start_child(SupName, Child) ->
     #child{mfargs = {M, F, Args}} = Child,
-    case catch apply(M, F, Args) of
+    try apply(M, F, Args) of
         {ok, Pid} when is_pid(Pid) ->
             NChild = Child#child{pid = Pid},
             report_progress(NChild, SupName),
@@ -419,12 +419,13 @@ do_start_child(SupName, Child) ->
             {ok, Pid, Extra};
         ignore ->
             {ok, undefined};
-        {error, What} -> {error, What};
-        What -> {error, What}
+        {error, What} -> {error, What}
+    catch
+        C:What -> {error, {C, What}}
     end.
 
 do_start_child_i(M, F, A) ->
-    case catch apply(M, F, A) of
+    try apply(M, F, A) of
         {ok, Pid} when is_pid(Pid) ->
             {ok, Pid};
         {ok, Pid, Extra} when is_pid(Pid) ->
@@ -432,9 +433,10 @@ do_start_child_i(M, F, A) ->
         ignore ->
             {ok, undefined};
         {error, Error} ->
-            {error, Error};
-        What ->
-            {error, What}
+            {error, Error}
+    catch
+        C:What ->
+            {error, {C, What}}
     end.
 
 %%% ---------------------------------------------------
@@ -754,15 +756,16 @@ terminate(_Reason, State) ->
 code_change(_, State, _) ->
     case (State#state.module):init(State#state.args) of
         {ok, {SupFlags, StartSpec}} ->
-            case catch check_flags(SupFlags) of
+            try check_flags(SupFlags) of
                 ok ->
                     {Strategy, MaxIntensity, Period} = SupFlags,
                     update_childspec(State#state{strategy = Strategy,
                                                  intensity = MaxIntensity,
                                                  period = Period},
-                                     StartSpec);
-                Error ->
-                    {error, Error}
+                                     StartSpec)
+            catch
+                C:Error ->
+                    {error, {C, Error}}
             end;
         ignore ->
             {ok, State};
@@ -1419,13 +1422,14 @@ remove_child(Child, State) ->
 %% Returns: {ok, state()} | Error
 %%-----------------------------------------------------------------
 do_init(SupName, Type, StartSpec, Mod, Args) ->
-    case catch init_state(SupName, Type, Mod, Args) of
+    try init_state(SupName, Type, Mod, Args) of
         {ok, State} when ?is_simple(State) ->
             init_dynamic(State, StartSpec);
         {ok, State} ->
-            init_children(State, StartSpec);
-        Error ->
-            {stop, {supervisor_data, Error}}
+            init_children(State, StartSpec)
+    catch
+        C:Error ->
+            {stop, {supervisor_data, {C, Error}}}
     end.
 
 init_state(SupName, {Strategy, MaxIntensity, Period}, Mod, Args) ->
@@ -1489,7 +1493,12 @@ check_startspec([], Res) ->
     {ok, lists:reverse(Res)}.
 
 check_childspec({Name, Func, RestartType, Shutdown, ChildType, Mods}) ->
-    catch check_childspec(Name, Func, RestartType, Shutdown, ChildType, Mods);
+    try
+        check_childspec(Name, Func, RestartType, Shutdown, ChildType, Mods)
+    catch
+        C:Reason ->
+            {C, Reason}
+    end;
 check_childspec(X) -> {invalid_child_spec, X}.
 
 check_childspec(Name, Func, RestartType, Shutdown, ChildType, Mods) ->

--- a/test/brod_group_coordinator_SUITE.erl
+++ b/test/brod_group_coordinator_SUITE.erl
@@ -107,7 +107,7 @@ t_acks_during_revoke(Config) when is_list(Config) ->
 
   {ok, GroupCoordinator2Pid} =
     brod_group_coordinator:start_link(?OTHER_CLIENT_ID, ?GROUP, [?TOPIC],
-                                      _Config = [], ?MODULE, {self(), 2}),
+                                      [], ?MODULE, {self(), 2}),
 
   %% Allow new partition to be started
   ?assert_receive({assignments_revoked, 2}, ok),

--- a/test/brod_group_subscriber_SUITE.erl
+++ b/test/brod_group_subscriber_SUITE.erl
@@ -125,7 +125,7 @@ common_init_per_testcase(Case, Config0) ->
 common_end_per_testcase(Case, Config) ->
   %% Clean up stuff while trying not to be killed by brod
   process_flag(trap_exit, true),
-  catch brod:stop_client(?CLIENT_ID),
+  try brod:stop_client(?CLIENT_ID) catch _:_ -> ok end,
   kafka_test_helper:common_end_per_testcase(Case, Config),
   receive
     {'EXIT', From, Reason} ->

--- a/test/kafka_test_helper.erl
+++ b/test/kafka_test_helper.erl
@@ -44,7 +44,11 @@ common_init_per_testcase(Module, Case, Config) ->
   Config.
 
 common_end_per_testcase(_Case, _Config) ->
-  catch brod:stop_client(?TEST_CLIENT_ID),
+  try
+      brod:stop_client(?TEST_CLIENT_ID)
+  catch
+      _:_ -> ok
+  end,
   ok.
 
 produce(TopicPartition, Value) ->


### PR DESCRIPTION
This removes all old style catch statements and uses the new syntax. Also a no longer allowed "setting of variable" inside a function call is removed.

Should now compile and test cleanly on OTP-29.
